### PR TITLE
Run hubot in Slack mode

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
 
 if [ "$1" == "bot" ]; then
   shift
-  exec node_modules/.bin/hubot --name "issuebot" "$@"
+  exec node_modules/.bin/hubot --adapter slack --name "issuebot" "$@"
 else
   exec $*
 fi


### PR DESCRIPTION
When adapter is unspecified, hubot defaults to an interactive console. Great for testing, less useful for production.